### PR TITLE
Include EasyAccess in ActionController only after it has been loaded.

### DIFF
--- a/lib/http_accept_language/railtie.rb
+++ b/lib/http_accept_language/railtie.rb
@@ -3,7 +3,10 @@ module HttpAcceptLanguage
 
     initializer "http_accept_language.add_middleware" do |app|
       app.middleware.use Middleware
-      ApplicationController.send :include, EasyAccess
+      
+      ActiveSupport.on_load :action_controller do
+        include EasyAccess
+      end
     end
 
   end


### PR DESCRIPTION
The direct include caused some issues for me, for example the helpers in `app/helpers/` were never loaded.
