### PR TITLE
Don't crash when used while middleware was not applied.

### DIFF
--- a/lib/http_accept_language/railtie.rb
+++ b/lib/http_accept_language/railtie.rb
@@ -12,9 +12,11 @@ module HttpAcceptLanguage
   end
 
   module EasyAccess
+
     def http_accept_language
-      env.http_accept_language
+      @http_accept_language ||= env.respond_to?(:http_accept_language) ? env.http_accept_language : Parser.new("")
     end
+
   end
 
 end


### PR DESCRIPTION
Middleware are not always applied when running specs.
