### PR TITLE
Fix accidental reuse of Parser object in Rack Middleware.

### DIFF
--- a/lib/http_accept_language/middleware.rb
+++ b/lib/http_accept_language/middleware.rb
@@ -6,8 +6,9 @@ module HttpAcceptLanguage
     end
 
     def call(env)
+      env["http_accept_language"] = Parser.new(env['HTTP_ACCEPT_LANGUAGE'])
       def env.http_accept_language
-        @http_accept_language ||= Parser.new(self['HTTP_ACCEPT_LANGUAGE'])
+        self["http_accept_language"]
       end
       @app.call(env)
     end


### PR DESCRIPTION
The current Rack middleware implementation does not always assign a new parser instance to the environment.

If the Rack server reuses the same "env" instance between requests (e.g., Unicorn) this can cause parsers created for previous requests to incorrectly be re-used for the current request.
