### PR TITLE
Don't double load VERSION constant.

### DIFF
--- a/lib/http_accept_language.rb
+++ b/lib/http_accept_language.rb
@@ -1,4 +1,3 @@
-require 'http_accept_language/version'
 require 'http_accept_language/parser'
 require 'http_accept_language/middleware'
 require 'http_accept_language/railtie' if defined?(Rails::Railtie)


### PR DESCRIPTION
It's being loaded in the gemspec by a different path, so loading it again here causes a constant redefinition on 1.8.
