### PR TITLE
Accept available languages as symbols on #sanitize_available_locales

### DIFF
--- a/lib/http_accept_language/parser.rb
+++ b/lib/http_accept_language/parser.rb
@@ -73,7 +73,7 @@ module HttpAcceptLanguage
     #
     def sanitize_available_locales(available_languages)
       available_languages.map do |available|
-        available.split(/[_-]/).reject { |part| part.start_with?("x") }.join("-")
+        available.to_s.split(/[_-]/).reject { |part| part.start_with?("x") }.join("-")
       end
     end
 
@@ -90,7 +90,6 @@ module HttpAcceptLanguage
       available_languages = sanitize_available_locales(available_languages)
       user_preferred_languages.map do |preferred| #en-US
         lang_group = available_languages.select do |available| # en
-          available = available.to_s
           preferred.split('-', 2).first == available.split('-', 2).first
         end
         lang_group.find { |lang| lang == preferred } || lang_group.first #en-US, en-UK

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -48,6 +48,10 @@ describe HttpAcceptLanguage::Parser do
     parser.sanitize_available_locales(%w{en_UK-x3 en-US-x1 ja_JP-x2 pt-BR-x5 es-419-x4}).should eq ["en-UK", "en-US", "ja-JP", "pt-BR", "es-419"]
   end
 
+  it "should accept available language names as symbols and return them as strings" do
+    parser.sanitize_available_locales([:en, :"en-US", :ca, :"ca-ES"]).should eq ["en", "en-US", "ca", "ca-ES"]
+  end
+
   it "should find most compatible language from user preferred" do
     parser.header = 'ja,en-gb,en-us,fr-fr'
     parser.language_region_compatible_from(%w{en-UK en-US ja-JP}).should eq "ja-JP"


### PR DESCRIPTION
Quick fix to make work `#language_region_compatible_from` directly with the array of symbols stored at `I18n.available_locales` on Rails.
