### PR TITLE
Setup a new parser outside of Middleware using HTTP_ACCEPT_LANGUAGE dire...

### DIFF
--- a/lib/http_accept_language/railtie.rb
+++ b/lib/http_accept_language/railtie.rb
@@ -11,7 +11,7 @@ module HttpAcceptLanguage
 
   module EasyAccess
     def http_accept_language
-      @http_accept_language ||= request.env["http_accept_language.parser"] || Parser.new("")
+      @http_accept_language ||= request.env["http_accept_language.parser"] || Parser.new(request.env["HTTP_ACCEPT_LANGUAGE"])
     end
   end
 end


### PR DESCRIPTION
...ctly

Allows you to use the gem outside of environments where the middleware does not run, such as controller specs.
