### PR TITLE
Fixes an issue when parsing headers with a wildcard in the language-range.

### DIFF
--- a/lib/http_accept_language/parser.rb
+++ b/lib/http_accept_language/parser.rb
@@ -18,15 +18,17 @@ module HttpAcceptLanguage
       @user_preferred_languages ||= begin
         header.to_s.gsub(/\s+/, '').split(',').map do |language|
           locale, quality = language.split(';q=')
-          raise ArgumentError, 'Not correctly formatted' unless locale =~ /^[a-z\-0-9]+$/i
+          raise ArgumentError, 'Not correctly formatted' unless locale =~ /^[a-z\-0-9]+|\*$/i
 
           locale  = locale.downcase.gsub(/-[a-z0-9]+$/i, &:upcase) # Uppercase territory
+          locale  = nil if locale == '*' # Ignore wildcards
+
           quality = quality ? quality.to_f : 1.0
 
           [locale, quality]
         end.sort do |(_, left), (_, right)|
           right <=> left
-        end.map(&:first)
+        end.map(&:first).compact
       rescue ArgumentError # Just rescue anything if the browser messed up badly.
         []
       end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -44,6 +44,11 @@ describe HttpAcceptLanguage::Parser do
     parser.compatible_language_from([:"en-HK"]).should eq :"en-HK"
   end
 
+  it "should accept and ignore wildcards" do
+    parser.header = 'en-US,en,*'
+    parser.compatible_language_from([:"en-US"]).should eq :"en-US"
+  end
+
   it "should sanitize available language names" do
     parser.sanitize_available_locales(%w{en_UK-x3 en-US-x1 ja_JP-x2 pt-BR-x5 es-419-x4}).should eq ["en-UK", "en-US", "ja-JP", "pt-BR", "es-419"]
   end


### PR DESCRIPTION
According to RFC2616 the parser should accept wildcards.

For now it may be save to ignore them.
However in a future implementation the wildcard should match any language
given by the 'available_languages' array in methods determinating a preferred
or compatible language for the user.
