### PR TITLE
fix auto_locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ class SomeController < ApplicationController
 end
 ```
 
-If you want to enable this behavior by default in all of your controllers, add the following in an initializer (`config/initializers/http_accept_language.rb`, for example):
+If you want to enable this behavior by default in your controllers, you can just include the provided concern:
 
 ```ruby
-HttpAcceptLanguage.automatically_set_locale = true
+class ApplicationController < ActionController::Base
+  include HttpAcceptLanguage::AutoLocale
+
+#...
+end
 ```
 
 To use the middleware in any Rack application, simply add the middleware:

--- a/lib/http_accept_language.rb
+++ b/lib/http_accept_language.rb
@@ -1,15 +1,4 @@
-module HttpAcceptLanguage
-  @@automatically_set_locale = false
-
-  def self.automatically_set_locale?
-    @@automatically_set_locale
-  end
-
-  def self.automatically_set_locale=(set_locale)
-    @@automatically_set_locale = set_locale
-  end
-end
-
+require 'http_accept_language/auto_locale'
 require 'http_accept_language/parser'
 require 'http_accept_language/middleware'
 require 'http_accept_language/railtie' if defined?(Rails::Railtie)

--- a/lib/http_accept_language/auto_locale.rb
+++ b/lib/http_accept_language/auto_locale.rb
@@ -1,5 +1,4 @@
-require "active_support/concern"
-require "i18n"
+require 'active_support/concern'
 
 module HttpAcceptLanguage
   module AutoLocale
@@ -8,6 +7,8 @@ module HttpAcceptLanguage
     included do
       before_filter :set_locale
     end
+
+    private
 
     def set_locale
       I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)

--- a/lib/http_accept_language/railtie.rb
+++ b/lib/http_accept_language/railtie.rb
@@ -1,15 +1,10 @@
 module HttpAcceptLanguage
   class Railtie < ::Rails::Railtie
-    initializer "http_accept_language.setup" do |app|
+    initializer "http_accept_language.add_middleware" do |app|
       app.middleware.use Middleware
 
       ActiveSupport.on_load :action_controller do
         include EasyAccess
-
-        if HttpAcceptLanguage.automatically_set_locale?
-          require "http_accept_language/auto_locale"
-          include AutoLocale
-        end
       end
     end
   end

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -1,10 +1,13 @@
+require 'i18n'
 require 'http_accept_language/auto_locale'
+require 'http_accept_language/parser'
+require 'http_accept_language/middleware'
 
 describe HttpAcceptLanguage::AutoLocale do
   let(:controller_class) do
     Class.new do
-      def self.before_filter(dummy) 
-
+      def self.before_filter(dummy)
+        # dummy method
       end
 
       def http_accept_language
@@ -23,22 +26,9 @@ describe HttpAcceptLanguage::AutoLocale do
     end
 
     it "take a suitable locale" do
-      controller.set_locale
+      controller.send(:set_locale)
 
       expect(I18n.locale).to eq(:ja)
-    end
-  end
-
-  context "available languages not includes accept_languages" do
-    before do
-      I18n.available_locales = [:de]
-      I18n.default_locale = :fr
-    end
-
-    it "take default_locale" do
-      controller.set_locale
-
-      expect(I18n.locale).to eq(:fr)
     end
   end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -33,20 +33,20 @@ describe "Rack integration" do
     app = lambda { |env| env }
     middleware = HttpAcceptLanguage::Middleware.new(app)
     middleware.call(env)
-    env.http_accept_language.user_preferred_languages.should eq %w{en}
+    expect(env.http_accept_language.user_preferred_languages).to eq %w{en}
     env["HTTP_ACCEPT_LANGUAGE"] = "de"
     middleware.call(env)
-    env.http_accept_language.user_preferred_languages.should eq %w{de}
+    expect(env.http_accept_language.user_preferred_languages).to eq %w{de}
   end
 
   it "decodes the HTTP_ACCEPT_LANGUAGE header" do
     request_with_header 'en-us,en-gb;q=0.8,en;q=0.6,es-419'
-    r['user_preferred_languages'].should eq %w{en-US es-419 en-GB en}
+    expect(r['user_preferred_languages']).to eq %w{en-US es-419 en-GB en}
   end
 
   it "finds the first available language" do
     request_with_header 'en-us,en-gb;q=0.8,en;q=0.6,es-419', :preferred => %w(en en-GB)
-    r['preferred_language_from'].should eq 'en-GB'
+    expect(r['preferred_language_from']).to eq 'en-GB'
   end
 
   def request_with_header(header, params = {})

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -8,58 +8,58 @@ describe HttpAcceptLanguage::Parser do
 
   it "should return empty array" do
     parser.header = nil
-    parser.user_preferred_languages.should eq []
+    expect(parser.user_preferred_languages).to eq []
   end
 
   it "should properly split" do
-    parser.user_preferred_languages.should eq %w{en-US es-419 en-GB en}
+    expect(parser.user_preferred_languages).to eq %w{en-US es-419 en-GB en}
   end
 
   it "should ignore jambled header" do
     parser.header = 'odkhjf89fioma098jq .,.,'
-    parser.user_preferred_languages.should eq []
+    expect(parser.user_preferred_languages).to eq []
   end
 
   it "should properly respect whitespace" do
     parser.header = 'en-us, en-gb; q=0.8,en;q = 0.6,es-419'
-    parser.user_preferred_languages.should eq %w{en-US es-419 en-GB en}
+    expect(parser.user_preferred_languages).to eq %w{en-US es-419 en-GB en}
   end
 
   it "should find first available language" do
-    parser.preferred_language_from(%w{en en-GB}).should eq "en-GB"
+    expect(parser.preferred_language_from(%w{en en-GB})).to eq "en-GB"
   end
 
   it "should find first compatible language" do
-    parser.compatible_language_from(%w{en-hk}).should eq "en-hk"
-    parser.compatible_language_from(%w{en}).should eq "en"
+    expect(parser.compatible_language_from(%w{en-hk})).to eq "en-hk"
+    expect(parser.compatible_language_from(%w{en})).to eq "en"
   end
 
   it "should find first compatible from user preferred" do
     parser.header = 'en-us,de-de'
-    parser.compatible_language_from(%w{de en}).should eq 'en'
+    expect(parser.compatible_language_from(%w{de en})).to eq 'en'
   end
 
   it "should accept symbols as available languages" do
     parser.header = 'en-us'
-    parser.compatible_language_from([:"en-HK"]).should eq :"en-HK"
+    expect(parser.compatible_language_from([:"en-HK"])).to eq :"en-HK"
   end
 
   it "should accept and ignore wildcards" do
     parser.header = 'en-US,en,*'
-    parser.compatible_language_from([:"en-US"]).should eq :"en-US"
+    expect(parser.compatible_language_from([:"en-US"])).to eq :"en-US"
   end
 
   it "should sanitize available language names" do
-    parser.sanitize_available_locales(%w{en_UK-x3 en-US-x1 ja_JP-x2 pt-BR-x5 es-419-x4}).should eq ["en-UK", "en-US", "ja-JP", "pt-BR", "es-419"]
+    expect(parser.sanitize_available_locales(%w{en_UK-x3 en-US-x1 ja_JP-x2 pt-BR-x5 es-419-x4})).to eq ["en-UK", "en-US", "ja-JP", "pt-BR", "es-419"]
   end
 
   it "should accept available language names as symbols and return them as strings" do
-    parser.sanitize_available_locales([:en, :"en-US", :ca, :"ca-ES"]).should eq ["en", "en-US", "ca", "ca-ES"]
+    expect(parser.sanitize_available_locales([:en, :"en-US", :ca, :"ca-ES"])).to eq ["en", "en-US", "ca", "ca-ES"]
   end
 
   it "should find most compatible language from user preferred" do
     parser.header = 'ja,en-gb,en-us,fr-fr'
-    parser.language_region_compatible_from(%w{en-UK en-US ja-JP}).should eq "ja-JP"
+    expect(parser.language_region_compatible_from(%w{en-UK en-US ja-JP})).to eq "ja-JP"
   end
 
 end


### PR DESCRIPTION
fixes the issues introduced by #36 

work in progress:
- [x] fix specs
- [x] use `expect`-syntax instead of deprecated `should`
- [ ] add specs if needed
- [x] check if constants get found and loaded correctly
- [x] check if commit revert covers everything