### PR TITLE
Use around_filter/_action and I18n.with_locale

### DIFF
--- a/lib/http_accept_language/auto_locale.rb
+++ b/lib/http_accept_language/auto_locale.rb
@@ -5,13 +5,18 @@ module HttpAcceptLanguage
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_locale
+      if respond_to?(:around_action)
+        around_action :use_locale
+      else
+        arund_filter :use_locale
+      end
     end
 
     private
 
-    def set_locale
-      I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+    def use_locale(&blk)
+      locale = http_accept_language.compatible_language_from(I18n.available_locales)
+      I18n.with_locale(locale, &blk)
     end
   end
 end

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -6,7 +6,7 @@ require 'http_accept_language/middleware'
 describe HttpAcceptLanguage::AutoLocale do
   let(:controller_class) do
     Class.new do
-      def self.before_filter(dummy)
+      def self.around_action(dummy)
         # dummy method
       end
 
@@ -26,9 +26,11 @@ describe HttpAcceptLanguage::AutoLocale do
     end
 
     it "take a suitable locale" do
-      controller.send(:set_locale)
-
-      expect(I18n.locale).to eq(:ja)
+      expect(I18n.locale).to eq(:en)
+      controller.send(:use_locale) do
+        expect(I18n.locale).to eq(:ja)
+      end
+      expect(I18n.locale).to eq(:en)
     end
   end
 end


### PR DESCRIPTION
As the `I18n.locale`-attribute will persist across several requests to the Rails application, I think it's better to use `around_action` and `I18n.with_locale` in the `HttpAcceptLanguage::AutoLocale` controller mixin.

I'm not sure Rails 3 has `around_action` (it does have `around_filter`). I've added a conditional check to make sure `around_action` is available, if not fallback to `around_filter`.
