### PR TITLE
Default `Accept-Language` to `I18n.default_locale`

### DIFF
--- a/lib/http_accept_language/auto_locale.rb
+++ b/lib/http_accept_language/auto_locale.rb
@@ -11,7 +11,9 @@ module HttpAcceptLanguage
     private
 
     def set_locale
-      I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+      hal = http_accept_language
+      hal.header ||= I18n.default_locale.to_s
+      I18n.locale = hal.compatible_language_from(I18n.available_locales)
     end
   end
 end

--- a/lib/http_accept_language/auto_locale.rb
+++ b/lib/http_accept_language/auto_locale.rb
@@ -11,9 +11,7 @@ module HttpAcceptLanguage
     private
 
     def set_locale
-      hal = http_accept_language
-      hal.header ||= I18n.default_locale.to_s
-      I18n.locale = hal.compatible_language_from(I18n.available_locales)
+      I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales) || I18n.default_locale
     end
   end
 end

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -6,19 +6,24 @@ require 'http_accept_language/middleware'
 describe HttpAcceptLanguage::AutoLocale do
   let(:controller_class) do
     Class.new do
+      def initialize(header = nil)
+        super()
+        @header = header
+      end
+
       def self.before_filter(dummy)
         # dummy method
       end
 
       def http_accept_language
-        HttpAcceptLanguage::Parser.new("ja,en-us;q=0.7,en;q=0.3")
+        @http_accept_language ||= HttpAcceptLanguage::Parser.new(@header)
       end
 
       include HttpAcceptLanguage::AutoLocale
     end
   end
 
-  let(:controller) { controller_class.new }
+  let(:controller) { controller_class.new("ja,en-us;q=0.7,en;q=0.3") }
 
   context "available languages includes accept_languages" do
     before do
@@ -27,6 +32,21 @@ describe HttpAcceptLanguage::AutoLocale do
 
     it "take a suitable locale" do
       controller.send(:set_locale)
+
+      expect(I18n.locale).to eq(:ja)
+    end
+  end
+
+  let(:no_accept_language_controller) { controller_class.new() }
+
+  context "default locale is ja" do
+    before do
+      I18n.default_locale = :ja
+      I18n.available_locales = [:en, :ja]
+    end
+
+    it "set the locale to default" do
+      no_accept_language_controller.send(:set_locale)
 
       expect(I18n.locale).to eq(:ja)
     end

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -37,12 +37,25 @@ describe HttpAcceptLanguage::AutoLocale do
     end
   end
 
+  context "available languages do not include accept_languages" do
+    before do
+      I18n.available_locales = [:es]
+      I18n.default_locale = :es
+    end
+
+    it "set the locale to default" do
+      no_accept_language_controller.send(:set_locale)
+
+      expect(I18n.locale).to eq(:es)
+    end
+  end
+
   let(:no_accept_language_controller) { controller_class.new() }
 
   context "default locale is ja" do
     before do
-      I18n.default_locale = :ja
       I18n.available_locales = [:en, :ja]
+      I18n.default_locale = :ja
     end
 
     it "set the locale to default" do


### PR DESCRIPTION
Currently AutoLocale tries to set `I18n.locale` to nil when the Accept-Language header is missing, which leads to "nil is not a valid locale" error when `I18n.config.enforce_available_locales` is true (default).

This commit fixes the problem by defaulting the header value to `I18n.default_locale`.