### PR TITLE
Use prepend_before_action rather than before_filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2
+  - 2.2.5
+  - 2.3.1
 script: bundle exec rspec spec

--- a/http_accept_language.gemspec
+++ b/http_accept_language.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'guard-rspec'
-  s.add_development_dependency 'rails', '>= 3.2.6'
+  s.add_development_dependency 'rails', ['>= 3.2.6', *('< 5' if RUBY_VERSION < '2.2.2')]
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'
 end

--- a/http_accept_language.gemspec
+++ b/http_accept_language.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'guard-rspec'
+  s.add_development_dependency 'listen', '< 3.1.0' if RUBY_VERSION < '2.2.5'
   s.add_development_dependency 'rails', ['>= 3.2.6', *('< 5' if RUBY_VERSION < '2.2.2')]
   s.add_development_dependency 'cucumber'
   s.add_development_dependency 'aruba'

--- a/lib/http_accept_language/auto_locale.rb
+++ b/lib/http_accept_language/auto_locale.rb
@@ -5,7 +5,11 @@ module HttpAcceptLanguage
     extend ActiveSupport::Concern
 
     included do
-      before_filter :set_locale
+      if respond_to?(:prepend_before_action)
+        prepend_before_action :set_locale
+      else
+        prepend_before_filter :set_locale
+      end
     end
 
     private

--- a/spec/auto_locale_spec.rb
+++ b/spec/auto_locale_spec.rb
@@ -11,7 +11,11 @@ describe HttpAcceptLanguage::AutoLocale do
         @header = header
       end
 
-      def self.before_filter(dummy)
+      def self.prepend_before_action(dummy)
+        # dummy method
+      end
+
+      def self.prepend_before_filter(dummy)
         # dummy method
       end
 


### PR DESCRIPTION
A locale should be set as earlier as possible because some before filters (like `require_no_authentication` in Devise) use I18n.t() for a localized flash message.

While at it, I changed the call to first try `prepend_before_action` and then fall back to `prepend_before_filter` to avoid Rails 5's deprecation warning.
