### PR TITLE
Add missing activesupport dependency

### DIFF
--- a/http_accept_language.gemspec
+++ b/http_accept_language.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_runtime_dependency 'activesupport', '>= 3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rack-test'


### PR DESCRIPTION
Hello, we're recently use this gem as rack middleware for our pure rack app, and found it doesn't specify active_support, which is used in auto_locale, as dependency.