### PR TITLE
rename deprecated `before_filter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can easily set the locale used for i18n in a before-filter:
 
 ```ruby
 class SomeController < ApplicationController
-  before_filter :set_locale
+  before_action :set_locale
 
   private
     def set_locale


### PR DESCRIPTION
https://github.com/rails/rails/blob/v5.0.0/actionpack/lib/abstract_controller/callbacks.rb#L190-L193

[ci skip]